### PR TITLE
Use explicit class name in add_command() for PHP < 5.5.0 compat.

### DIFF
--- a/command.php
+++ b/command.php
@@ -11,5 +11,5 @@ if ( is_readable( $autoloader ) ) {
 
 \WP_CLI::add_command(
 	'test-command',
-	TestCommand::class
+	'AlainSchlesser\TestCommand\TestCommand'
 );


### PR DESCRIPTION
Uses the explicit class name to avoid a PHP syntax error when run in PHP 5.3 - see https://travis-ci.org/gitlost/package-command/jobs/295595636 and https://github.com/gitlost/package-command/pull/1, as the special `::class constant` was only introduced PHP 5.5.0 [language.oop5.constants.php](http://php.net/manual/en/language.oop5.constants.php).